### PR TITLE
Added docker support for arm64 devices

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -29,3 +29,13 @@ jobs:
             commit=${{ github.sha }}
           push: true
           tags: nogil/python:latest
+
+      - name: Build and push Docker image for ARM64 devices
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/DockerfileARM64
+          build-args: |
+            commit=${{ github.sha }}
+          push: true
+          tags: nogil-arm64/python:latest

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -38,4 +38,4 @@ jobs:
           build-args: |
             commit=${{ github.sha }}
           push: true
-          tags: nogil-arm64/python:latest
+          tags: nogil/python-arm64:latest

--- a/docker/DockerfileARM64
+++ b/docker/DockerfileARM64
@@ -1,0 +1,60 @@
+# Copied from https://github.com/docker-library/python/blob/master/3.9/bullseye/Dockerfile
+
+FROM arm64v8/buildpack-deps:bullseye
+
+ARG commit
+
+# ensure local python is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
+# extra dependencies (over what buildpack-deps already includes)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libbluetooth-dev \
+		tk-dev \
+		uuid-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN set -ex \
+	\
+	&& wget -O python.tar.gz "https://github.com/colesbury/nogil/tarball/$commit" \
+	&& mkdir -p /usr/src/python \
+	&& tar -xC /usr/src/python --strip-components=1 -f python.tar.gz \
+	&& rm python.tar.gz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-optimizations \
+		--enable-option-checking=fatal \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+	&& make -j "$(nproc)" \
+	&& make install \
+	&& rm -rf /usr/src/python \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+		\) -exec rm -rf '{}' + \
+	\
+	&& ldconfig \
+	\
+	&& python3 --version
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+	&& ln -s idle3 idle \
+	&& ln -s pydoc3 pydoc \
+	&& ln -s python3 python \
+	&& ln -s python3-config python-config \
+	&& ln -s pip3 pip
+
+CMD ["python3"]


### PR DESCRIPTION
Fix #136 

For simplicity I added a separate Dockerfile for arm64 devices, and added another step to the publish_docker.yml to push the additional image to Dockerhub with tag "nogil-arm64/python"